### PR TITLE
Fix bug with '+' char on POST request encoding

### DIFF
--- a/Audioscrobbler.xcodeproj/project.pbxproj
+++ b/Audioscrobbler.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -254,9 +254,16 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0430;
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Audioscrobbler" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				en,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* Audioscrobbler */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -365,9 +372,9 @@
 			buildSettings = {
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				PRODUCT_NAME = Distribution;
-				ZERO_LINK = NO;
+				"SDKROOT[arch=*]" = macosx10.5;
+				ZERO_LINK = macosx10.7;
 			};
 			name = Release;
 		};
@@ -381,7 +388,6 @@
 					"\"$(SRCROOT)\"",
 				);
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -389,6 +395,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = __AS_DEBUGGING__;
 				INFOPLIST_FILE = Info.plist;
 				PRODUCT_NAME = Audioscrobbler;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -413,7 +420,7 @@
 				GCC_THREADSAFE_STATICS = NO;
 				INFOPLIST_FILE = Info.plist;
 				PRODUCT_NAME = Audioscrobbler;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -426,10 +433,9 @@
 				GCC_PREPROCESSOR_DEFINITIONS = __AS_DEBUGGING__;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				PREBINDING = NO;
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = NO;
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -444,9 +450,8 @@
 				GCC_VERSION = "";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				PREBINDING = YES;
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = NO;
-				SDKROOT = macosx10.5;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/MainController.m
+++ b/MainController.m
@@ -463,7 +463,7 @@ static NSString* downloads()
             CFRelease(item);
         }
     }
-    else if (item = audioscrobbler_session_login_item(login_items_ref)){
+    else if ((item = audioscrobbler_session_login_item(login_items_ref))){
         LSSharedFileListItemRemove(login_items_ref, item);
         [sender setState:NSOffState];
     }

--- a/lastfm.m
+++ b/lastfm.m
@@ -23,6 +23,8 @@
 #import <CommonCrypto/CommonDigest.h>
 
 #define KEYCHAIN_NAME "fm.last.Audioscrobbler"
+#define LASTFM_API_KEY ""
+#define LASTFM_SHARED_SECRET ""
 
 
 enum HTTPMethod { GET, POST };
@@ -97,9 +99,6 @@ static NSString* md5(NSString* s)
     return method
         ? [message stringByAppendingFormat:@" for method: %@.", method]
         : message;
-}
--(void)setMessage:(NSString*)s {
-    message = s;
 }
 @end
 


### PR DESCRIPTION
Audioscrobbler was triggering error on the lastfm POST API in case of track with artist, album or title with a '+' in the string.

The '+' needs to be % escaped in the POST body otherwise Lastfm return a signature error. 

There may be problem with other characters too as only '=' '&' and '%' and now '+' are the only escaped character instead of properly url escaping the string but I was unable to found any other.
