### PR TITLE
Fixed incorrect signature for some UTF characters on POST request encoding.

### DIFF
--- a/lastfm.m
+++ b/lastfm.m
@@ -188,7 +188,7 @@ static NSString* utf8_post_escape(NSString* s)
 
     for (int i = 0; i < N; ++i) {
         const unichar uc = [s characterAtIndex:i];
-        if (uc > 127 ) {
+        if (uc > 127) {
             continue;
         }
         const char c = ((char*)&uc)[0];


### PR DESCRIPTION
Hi,

This is related to issue #15 reported by @y8.
From what I have understood, the problem occurs with some multibytes UTF characters. Since the utf8_post_escape function needs to escape only some ASCII characters I just added a condition to ignore escaping on multibytes characters.
Hope this is correct (btw it's the first time I look at an Objective C project, so I did the simplest fix I could think of considering my lack of knowledge here, I'm sure a more elegant solution could be put instead).

Laurent.
